### PR TITLE
Add support for multiple-spaces separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function parse(str) {
 
     var parts = line
       .trim()
+      .replace(/ +/g, ' ')
       .split(' ');
 
     switch(parts[0]) {


### PR DESCRIPTION
I encountered invalid coordinates (missing Z value) while parsing [this teapot model](http://graphics.cs.williams.edu/data/meshes.xml#6).

This is due to the use of multiple spaces to separate the `v` prefix and its associated numeric values.

This PR adds robustness in this situation. By using this fix I was able to link this model.
